### PR TITLE
Add missing FLAGS parameters

### DIFF
--- a/inpaint_model.py
+++ b/inpaint_model.py
@@ -219,9 +219,8 @@ class InpaintCAModel(Model):
             batch_data, edge = batch_data
             edge = edge[:, :, :, 0:1] / 255.
             edge = tf.cast(edge > FLAGS.edge_threshold, tf.float32)
-        mask = brush_stroke_mask(name='mask_c')
-        regular_mask = bbox2mask(bbox, name='mask_c')
-        irregular_mask = brush_stroke_mask(name='mask_c')
+        regular_mask = bbox2mask(FLAGS, bbox, name='mask_c')
+        irregular_mask = brush_stroke_mask(FLAGS, name='mask_c')
         mask = tf.cast(
             tf.logical_or(
                 tf.cast(irregular_mask, tf.bool),
@@ -267,7 +266,7 @@ class InpaintCAModel(Model):
         # generate mask, 1 represents masked point
         bbox = (tf.constant(FLAGS.height//2), tf.constant(FLAGS.width//2),
                 tf.constant(FLAGS.height), tf.constant(FLAGS.width))
-        return self.build_infer_graph(batch_data, bbox, name)
+        return self.build_infer_graph(FLAGS, batch_data, bbox, name)
 
 
     def build_server_graph(self, FLAGS, batch_data, reuse=False, is_training=False):


### PR DESCRIPTION
Errors indicating missing parameters are thrown when `val` is set to `True` in `inpaint.yml`. This can be resolved by adding the `FLAGS` parameter in a number of lines.

Moreover, [line 222 in inpaint_model.py](https://github.com/JiahuiYu/generative_inpainting/blob/449d5f3399cf73c99c761131d4b2bf8f32c6a00a/inpaint_model.py#L222) is redundant.